### PR TITLE
Installation path bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- Version of `composer` in docker container updated up to `2.5.7`
+
+### Fixed
+
+- Expected type of installation path from composer installation manager
+
 ## v2.5.1
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.0-alpine
 
 ENV COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.5.3 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.5.7 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -81,7 +81,7 @@ final class Plugin implements PluginInterface, EventSubscriberInterface
         // Loop over all installed packages
         foreach ($composer->getRepositoryManager()->getLocalRepository()->getPackages() as $package) {
             $package_name = $package->getName();
-            $install_path = $installation_manager->getInstallPath($package);
+            $install_path = $installation_manager->getInstallPath($package) ?: '';
 
             $saved_size_bytes += self::makeClean($install_path, $global_rules, $fs, $io);
 
@@ -140,7 +140,7 @@ final class Plugin implements PluginInterface, EventSubscriberInterface
         $saved_size_bytes = 0;
         $package_rules    = Rules::getPackageRules();
 
-        $install_path = $composer->getInstallationManager()->getInstallPath($package);
+        $install_path = $composer->getInstallationManager()->getInstallPath($package) ?: '';
 
         // use global rules at first
         $saved_size_bytes += self::makeClean($install_path, Rules::getGlobalRules(), $fs, $io);


### PR DESCRIPTION
## Description

Fixed the expected type of installation path from composer installation manager.

The release of the composer `v2.5.6` contains the point:

`- BC Warning: Installers and InstallationManager::getInstallPath will now return null instead of an empty string for metapackages' paths. This may have adverse effects on plugin code using this expecting always a string but it is unlikely (#11455)`

See: [Composer changelog](https://github.com/composer/composer/blob/main/CHANGELOG.md) 

Fixes # ([issue-12](https://github.com/avto-dev/composer-cleanup-plugin/issues/12))

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

## Changelog

### Changed

- Version of `composer` in docker container updated up to `2.5.7`

### Fixed

- Expected type of installation path from composer installation manager
